### PR TITLE
Update verify account proof to new domain separation tag

### DIFF
--- a/contracts/FCLCrypto.cdc
+++ b/contracts/FCLCrypto.cdc
@@ -1,5 +1,5 @@
 pub contract FCLCrypto {
-    
+
     pub fun verifyUserSignatures(
         address: Address,
         message: String,
@@ -22,6 +22,13 @@ pub contract FCLCrypto {
         signatures: [String]
     ): Bool {
         return self.verifySignatures(
+            address: address,
+            message: message,
+            keyIndices: keyIndices,
+            signatures: signatures,
+            domainSeparationTag: self.domainSeparationTagAccountProof,
+        ) || 
+        self.verifySignatures(
             address: address,
             message: message,
             keyIndices: keyIndices,


### PR DESCRIPTION
### Adds support for new account-proof domain separation tag

- `verifyAccountProof` function returns true for either `"FLOW-V0.0-user"` or `"FCL-ACCOUNT-PROOF-V0.0"` domainSeparationTags